### PR TITLE
Update cron job schedule to 4am EST

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -2,7 +2,7 @@ name: Check Build Status
 
 on:
   schedule:
-    - cron: "0 11 * * *" # 7am EST
+    - cron: "0 9 * * *" # 4am EST
   workflow_dispatch: # Allows manual triggering
 
 jobs:


### PR DESCRIPTION
The cron job in `.github/workflows/blank.yml` was previously scheduled to run at 11:00 AM UTC (6:00 AM EST). This commit changes the schedule to 9:00 AM UTC (4:00 AM EST) as you requested.